### PR TITLE
Feature: Type-safe paths

### DIFF
--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -16,7 +16,7 @@ describe('client', () => {
 
     beforeEach(() => {
       products = fixtures.getProducts();
-      getProducts = new EndpointDefinition<Empty, Empty, Product[]>('/products');
+      getProducts = new EndpointDefinition<Empty, Empty, Product[]>(path => path.literal('products'));
 
       axiosMock = partialMockOf<typeof axios>({
         request: sinon.stub().returns(Promise.resolve({

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -11,7 +11,7 @@ describe('server', () => {
     let todos: Todo[];
 
     beforeEach(() => {
-      getTodos = new EndpointDefinition<Empty, Empty, Todo[]>('/todos');
+      getTodos = new EndpointDefinition<Empty, Empty, Todo[]>(path => path.literal('todos'));
       todos = [{
         id: '1',
         title: 'Write todo app',

--- a/src/shared.test.ts
+++ b/src/shared.test.ts
@@ -7,32 +7,29 @@ describe('shared', () => {
   describe('EndpointDefinition', () => {
     it('should return an endpoint definition with the specified method and path', () => {
       const method = 'POST';
-      const path = '/products';
-      const addProduct = new EndpointDefinition<Empty, Product, Product>(method, path);
+      const addProduct = new EndpointDefinition<Empty, Product, Product>(method, path => path.literal('products'));
 
       expect(addProduct).to.not.be.null;
       expect(addProduct).to.have.property('method', method);
-      expect(addProduct).to.have.property('path', path);
+      expect(addProduct).to.have.property('path', '/products');
     });
 
     it('should default a GET method if method is not specified', () => {
-      const path = '/products';
-      const getProducts = new EndpointDefinition<Empty, Empty, Product[]>(path);
+      const getProducts = new EndpointDefinition<Empty, Empty, Product[]>(path => path.literal('products'));
 
       expect(getProducts).to.not.be.null;
       expect(getProducts).to.have.property('method', 'GET');
-      expect(getProducts).to.have.property('path', path);
+      expect(getProducts).to.have.property('path', '/products');
     });
 
     it('should error if method is not supported', () => {
       const method = 'SQUANCH';
-      const path = '/products';
-      expect(() => new EndpointDefinition<Empty, Empty, Product[]>(method as any, path)).to.throw('Unsupported HTTP method: SQUANCH');
+      expect(() => new EndpointDefinition<Empty, Empty, Product[]>(method as any, path => path.literal('products'))).to.throw('Unsupported HTTP method: SQUANCH');
     });
 
     it('should error when trying to reference typeInfo', () => {
       const path = '/products';
-      const getProducts = new EndpointDefinition<Empty, Empty, Product[]>(path);
+      const getProducts = new EndpointDefinition<Empty, Empty, Product[]>(path => path.literal('products'));
       expect(() => getProducts.typeInfo()).to.throw(
         'Do not evaluate EndpointDefinition.typeInfo(). It is reserved for internal use only.'
       );
@@ -55,10 +52,9 @@ describe('shared', () => {
       }
 
       const method = 'GET';
-      const path = '/clients/:id';
       const getClient = new EndpointDefinition<GetClientRequestParams, Empty, Client>({
         method,
-        path,
+        path: path => path.literal('clients').param('id'),
         requestParams: GetClientRequestParams,
         requestBody: Empty,
         responseBody: Client
@@ -66,7 +62,7 @@ describe('shared', () => {
 
       expect(getClient).to.not.be.null;
       expect(getClient).to.have.property('method', method);
-      expect(getClient).to.have.property('path', path);
+      expect(getClient).to.have.property('path', '/clients/:id');
       expect(getClient.classInfo).to.be.an('object');
       expect(getClient.classInfo)
         .to.have.property('request')
@@ -96,9 +92,8 @@ describe('shared', () => {
 
       const arrayOfClient = arrayOf(Client);
 
-      const path = '/clients';
       const getClients = new EndpointDefinition({
-        path,
+        path: path => path.literal('clients'),
         requestParams: GetClientsParams,
         requestBody: Empty,
         responseBody: arrayOfClient
@@ -106,7 +101,7 @@ describe('shared', () => {
 
       expect(getClients).to.not.be.null;
       expect(getClients).to.have.property('method', 'GET');
-      expect(getClients).to.have.property('path', path);
+      expect(getClients).to.have.property('path', '/clients');
       expect(getClients.classInfo).to.be.an('object');
       expect(getClients.classInfo)
         .to.have.property('request')
@@ -159,4 +154,5 @@ describe('shared', () => {
       expect(isArrayOf(ArrayOfUser)).to.be.false;
     });
   });
+
 });

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -2,6 +2,7 @@ import { If } from 'typelevel-ts';
 
 import { argumentsToArray } from './shared/functions';
 import { cleanseHttpMethod, HttpMethod, HttpMethods } from './shared/http';
+import { createPath, PathBuildingFunction } from './shared/pathBuilder';
 import { PathHelper, PathHelperParseMatch } from './shared/pathHelper';
 
 export interface Constructor<T> {
@@ -89,7 +90,7 @@ export interface BaseEndpointDefinitionOptions<
   > {
 
   method?: string;
-  path: string;
+  path: PathBuildingFunction<TRequestParams>;
 
 }
 
@@ -198,8 +199,8 @@ export class EndpointDefinition<
   // tslint:enable:ban-types
   private pathHelper: PathHelper;
 
-  constructor(path: string);
-  constructor(method: HttpMethod, path: string);
+  constructor(buildPath: PathBuildingFunction<TRequestParams>);
+  constructor(method: HttpMethod, buildPath: PathBuildingFunction<TRequestParams>);
   // tslint:disable-next-line:unified-signatures
   constructor(options: EndpointDefinitionOptions<TRequestParams, TRequestBody, TResponseBody>);
 
@@ -212,7 +213,7 @@ export class EndpointDefinition<
           const options: EndpointDefinitionOptions<TRequestParams, TRequestBody, TResponseBody> = arguments[0];
 
           this.method = cleanseHttpMethod(options.method || DEFAULT_METHOD);
-          this.path = options.path;
+          this.path = createPath(options.path).toString();
           this.pathHelper = new PathHelper(this.path);
 
           if (isClassBasedEndpointDefinitionOptions(options)) {
@@ -222,9 +223,9 @@ export class EndpointDefinition<
               options.responseBody
             );
           }
-        } else if (typeof arguments[0] === 'string') {
+        } else if (typeof arguments[0] === 'function') {
           this.method = DEFAULT_METHOD;
-          this.path = arguments[0];
+          this.path = createPath(arguments[0]).toString();
           this.pathHelper = new PathHelper(this.path);
         } else {
           throw new EndpointDefinitionInvalidConstructorArgs(arguments);
@@ -234,7 +235,7 @@ export class EndpointDefinition<
 
       case 2: {
         this.method = cleanseHttpMethod(arguments[0]);
-        this.path = arguments[1];
+        this.path = createPath(arguments[1]).toString();
         this.pathHelper = new PathHelper(this.path);
         break;
       }

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -213,7 +213,7 @@ export class EndpointDefinition<
           const options: EndpointDefinitionOptions<TRequestParams, TRequestBody, TResponseBody> = arguments[0];
 
           this.method = cleanseHttpMethod(options.method || DEFAULT_METHOD);
-          this.path = createPath(options.path).toString();
+          this.path = createPath(options.path);
           this.pathHelper = new PathHelper(this.path);
 
           if (isClassBasedEndpointDefinitionOptions(options)) {
@@ -225,7 +225,7 @@ export class EndpointDefinition<
           }
         } else if (typeof arguments[0] === 'function') {
           this.method = DEFAULT_METHOD;
-          this.path = createPath(arguments[0]).toString();
+          this.path = createPath(arguments[0]);
           this.pathHelper = new PathHelper(this.path);
         } else {
           throw new EndpointDefinitionInvalidConstructorArgs(arguments);
@@ -235,7 +235,7 @@ export class EndpointDefinition<
 
       case 2: {
         this.method = cleanseHttpMethod(arguments[0]);
-        this.path = createPath(arguments[1]).toString();
+        this.path = createPath(arguments[1]);
         this.pathHelper = new PathHelper(this.path);
         break;
       }

--- a/src/shared/pathBuilder.test.ts
+++ b/src/shared/pathBuilder.test.ts
@@ -1,0 +1,68 @@
+import { expect } from 'chai';
+
+import { Empty } from '../shared';
+import { createPath } from './pathBuilder';
+
+describe('shared/pathBuilder', () => {
+  describe('createPath', () => {
+    interface ById {
+      id: string;
+    }
+
+    it('should generate an empty path by default', () => {
+      const result = createPath(path => path).toString();
+      expect(result).to.equal('/');
+    });
+
+    it('should generate a path with a literal', () => {
+      const result = createPath<Empty>(path => path
+        .literal('todos')
+      ).toString();
+
+      expect(result).to.equal('/todos');
+    });
+
+    it('should generate a path with a param', () => {
+      const result = createPath<ById>(path => path
+        .param('id')
+      ).toString();
+
+      expect(result).to.equal('/:id');
+    });
+
+    it('should generate a path with a literal and param', () => {
+      const result = createPath<ById>(path => path
+        .literal('todos')
+        .param('id')
+      ).toString();
+
+      expect(result).to.equal('/todos/:id');
+    });
+
+    it('should generate a path with a literal, param and literal', () => {
+      const result = createPath<ById>(path => path
+        .literal('todos')
+        .param('id')
+        .literal('tags')
+      ).toString();
+
+      expect(result).to.equal('/todos/:id/tags');
+    });
+
+    it('should generate a path with a literal, param, literal and param', () => {
+      interface ByTodoIdAndTagId {
+        todoId: string;
+        tagId: number;
+      }
+
+      const result = createPath<ByTodoIdAndTagId>(path => path
+        .literal('todos')
+        .param('todoId')
+        .literal('tags')
+        .param('tagId')
+      ).toString();
+
+      expect(result).to.equal('/todos/:todoId/tags/:tagId');
+    });
+  });
+});

--- a/src/shared/pathBuilder.test.ts
+++ b/src/shared/pathBuilder.test.ts
@@ -10,14 +10,14 @@ describe('shared/pathBuilder', () => {
     }
 
     it('should generate an empty path by default', () => {
-      const result = createPath(path => path).toString();
+      const result = createPath(path => path);
       expect(result).to.equal('/');
     });
 
     it('should generate a path with a literal', () => {
       const result = createPath<Empty>(path => path
         .literal('todos')
-      ).toString();
+      );
 
       expect(result).to.equal('/todos');
     });
@@ -25,7 +25,7 @@ describe('shared/pathBuilder', () => {
     it('should generate a path with a param', () => {
       const result = createPath<ById>(path => path
         .param('id')
-      ).toString();
+      );
 
       expect(result).to.equal('/:id');
     });
@@ -34,7 +34,7 @@ describe('shared/pathBuilder', () => {
       const result = createPath<ById>(path => path
         .literal('todos')
         .param('id')
-      ).toString();
+      );
 
       expect(result).to.equal('/todos/:id');
     });
@@ -44,7 +44,7 @@ describe('shared/pathBuilder', () => {
         .literal('todos')
         .param('id')
         .literal('tags')
-      ).toString();
+      );
 
       expect(result).to.equal('/todos/:id/tags');
     });
@@ -60,7 +60,7 @@ describe('shared/pathBuilder', () => {
         .param('todoId')
         .literal('tags')
         .param('tagId')
-      ).toString();
+      );
 
       expect(result).to.equal('/todos/:todoId/tags/:tagId');
     });

--- a/src/shared/pathBuilder.ts
+++ b/src/shared/pathBuilder.ts
@@ -27,12 +27,12 @@ export class PathBuilder<TRequestParams> {
 
 export type PathBuildingFunction<TRequestParams> = (path: PathBuilder<TRequestParams>) => PathBuilder<TRequestParams>;
 
-export function createPath<TRequestParams>(build: PathBuildingFunction<TRequestParams>): PathBuilder<TRequestParams> {
+export function createPath<TRequestParams>(build: PathBuildingFunction<TRequestParams>): string {
   class ConstructablePathBuilder extends PathBuilder<TRequestParams> {
     constructor() {
       super();
     }
   }
   const pathBuilder = build(new ConstructablePathBuilder());
-  return pathBuilder;
+  return pathBuilder.toString();
 }

--- a/src/shared/pathBuilder.ts
+++ b/src/shared/pathBuilder.ts
@@ -1,0 +1,38 @@
+export class PathBuilder<TRequestParams> {
+  private readonly parts: string[] = [];
+
+  // Marked as private to discourage consumers from instantiating directly.
+  // Use the createPath function instead
+  protected constructor() {
+  }
+
+  literal(path: string): PathBuilder<TRequestParams> {
+    if (path) {
+      this.parts.push(path);
+    }
+    return this;
+  }
+
+  param(name: keyof TRequestParams): PathBuilder<TRequestParams> {
+    if (name) {
+      this.parts.push(':' + name);
+    }
+    return this;
+  }
+
+  toString() {
+    return '/' + this.parts.join('/');
+  }
+}
+
+export type PathBuildingFunction<TRequestParams> = (path: PathBuilder<TRequestParams>) => PathBuilder<TRequestParams>;
+
+export function createPath<TRequestParams>(build: PathBuildingFunction<TRequestParams>): PathBuilder<TRequestParams> {
+  class ConstructablePathBuilder extends PathBuilder<TRequestParams> {
+    constructor() {
+      super();
+    }
+  }
+  const pathBuilder = build(new ConstructablePathBuilder());
+  return pathBuilder;
+}

--- a/tests/api/definitions/todos/create.ts
+++ b/tests/api/definitions/todos/create.ts
@@ -1,4 +1,6 @@
 import { Empty, EndpointDefinition } from '../../../../src/shared';
 import { Todo, UpdatableTodoFields } from '../../models/todo';
 
-export const createTodo = new EndpointDefinition<Empty, UpdatableTodoFields, Todo>('POST', '/todos');
+export const createTodo = new EndpointDefinition<Empty, UpdatableTodoFields, Todo>(
+  'POST', path => path.literal('todos')
+);

--- a/tests/api/definitions/todos/delete.ts
+++ b/tests/api/definitions/todos/delete.ts
@@ -2,4 +2,6 @@ import { Empty, EndpointDefinition } from '../../../../src/shared';
 import { HasId } from '../../models/hasId';
 import { Todo } from '../../models/todo';
 
-export const deleteTodo = new EndpointDefinition<HasId, Empty, Todo>('DELETE', '/todos/:id');
+export const deleteTodo = new EndpointDefinition<HasId, Empty, Todo>(
+  'DELETE', path => path.literal('todos').param('id')
+);

--- a/tests/api/definitions/todos/get.ts
+++ b/tests/api/definitions/todos/get.ts
@@ -2,4 +2,6 @@ import { Empty, EndpointDefinition } from '../../../../src/shared';
 import { HasId } from '../../models/hasId';
 import { Todo } from '../../models/todo';
 
-export const getTodo = new EndpointDefinition<HasId, Empty, Todo>('/todos/:id');
+export const getTodo = new EndpointDefinition<HasId, Empty, Todo>(
+  path => path.literal('todos').param('id')
+);

--- a/tests/api/definitions/todos/list.ts
+++ b/tests/api/definitions/todos/list.ts
@@ -1,4 +1,6 @@
 import { Empty, EndpointDefinition } from '../../../../src/shared';
 import { Todo } from '../../models/todo';
 
-export const getTodos = new EndpointDefinition<Empty, Empty, Todo[]>('/todos');
+export const getTodos = new EndpointDefinition<Empty, Empty, Todo[]>(
+  path => path.literal('todos')
+);

--- a/tests/api/definitions/todos/update.ts
+++ b/tests/api/definitions/todos/update.ts
@@ -2,4 +2,6 @@ import { EndpointDefinition } from '../../../../src/shared';
 import { HasId } from '../../models/hasId';
 import { Todo, UpdatableTodoFields } from '../../models/todo';
 
-export const updateTodo = new EndpointDefinition<HasId, UpdatableTodoFields, Todo>('PUT', '/todos/:id');
+export const updateTodo = new EndpointDefinition<HasId, UpdatableTodoFields, Todo>('PUT',
+  path => path.literal('todos').param('id')
+);


### PR DESCRIPTION
### Summary
Closes #2 by using @laurence-myers excellent suggestion of requiring consumers to build their path when defining an endpoint instead of just passing in a string. This forces a param to exist as a field on the request params type.

e.g.

```typescript
const getTodo = new EndpointDefinition<{ id: string }, Empty, Todo>(path => path.literal('todos').param('id'));
```

### Caveats
For now, does not offer consumers any new way of specifying type of params for later validation and/or coercion beyond the existing ability to do so via using something like `tsdv-joi`.